### PR TITLE
{fix} max_retries must have defualt value

### DIFF
--- a/src/Facades/StravaClient.php
+++ b/src/Facades/StravaClient.php
@@ -3,7 +3,6 @@
 namespace JordanPartridge\StravaClient\Facades;
 
 use Illuminate\Support\Facades\Facade;
-use JordanPartridge\StravaClient\StravaClient as StravaClientService;
 
 /**
  * @see \JordanPartridge\StravaClient\StravaClient

--- a/src/Facades/StravaClient.php
+++ b/src/Facades/StravaClient.php
@@ -12,6 +12,5 @@ class StravaClient extends Facade
 {
     protected static function getFacadeAccessor(): string
     {
-        return StravaClientService::class;
+        return 'strava-client';
     }
-}

--- a/src/Facades/StravaClient.php
+++ b/src/Facades/StravaClient.php
@@ -14,3 +14,4 @@ class StravaClient extends Facade
     {
         return 'strava-client';
     }
+}

--- a/src/StravaClient.php
+++ b/src/StravaClient.php
@@ -128,7 +128,7 @@ final class StravaClient
         }
 
         return match ($response->status()) {
-            self::HTTP_UNAUTHORIZED => $this->handleUnauthorized($request, $response),
+            self::HTTP_UNAUTHORIZED => $this->handleUnauthorized($request),
             self::HTTP_NOT_FOUND => throw new ResourceNotFoundException($response),
             self::HTTP_BAD_REQUEST => throw new BadRequestException($response),
             self::HTTP_RATE_LIMIT => throw new RateLimitExceededException($response),
@@ -146,9 +146,8 @@ final class StravaClient
      * @throws MaxAttemptsException
      * @throws RequestException
      */
-    private function handleUnauthorized(callable $request, $failed_response = null): array
+    private function handleUnauthorized(callable $request): array
     {
-        $this->current_attempts++;
         if ($this->current_attempts >= $this->max_refresh_attempts) {
             throw new MaxAttemptsException('Maximum token refresh attempts exceeded', 403);
         }

--- a/src/StravaClient.php
+++ b/src/StravaClient.php
@@ -22,9 +22,9 @@ final class StravaClient
 
     private const HTTP_RATE_LIMIT = 429;
 
-    private int $current_attempts;
+    private int $current_attempts;:w
 
-    public function __construct(private Connector $strava, private int $max_refresh_attempts)
+    public function __construct(private Connector $strava, private int $max_refresh_attempts = 3)
     {
         $this->current_attempts = 0;
 

--- a/src/StravaClient.php
+++ b/src/StravaClient.php
@@ -22,7 +22,7 @@ final class StravaClient
 
     private const HTTP_RATE_LIMIT = 429;
 
-    private int $current_attempts;:w
+    private int $current_attempts;
 
     public function __construct(private Connector $strava, private int $max_refresh_attempts = 3)
     {

--- a/src/StravaClientServiceProvider.php
+++ b/src/StravaClientServiceProvider.php
@@ -25,7 +25,10 @@ class StravaClientServiceProvider extends PackageServiceProvider
     public function packageBooted(): void
     {
         $this->app->bind('strava-client', function () {
-            new StravaClient(new Connector, config('strava-client.max_refresh_attempts'));
+            new StravaClient(
+                strava: new Connector,
+                max_refresh_attempts:  config('strava-client.max_refresh_attempts')
+            );
         });
 
         parent::packageBooted();

--- a/src/StravaClientServiceProvider.php
+++ b/src/StravaClientServiceProvider.php
@@ -27,7 +27,7 @@ class StravaClientServiceProvider extends PackageServiceProvider
         $this->app->bind('strava-client', function () {
             new StravaClient(
                 strava: new Connector,
-                max_refresh_attempts:  config('strava-client.max_refresh_attempts')
+                max_refresh_attempts: config('strava-client.max_refresh_attempts')
             );
         });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Simplified instantiation of the StravaClient by introducing a default value for the `max_refresh_attempts` parameter.
	- Updated the facade to use a string-based identifier for resolving the StravaClient service.

- **Bug Fixes**
	- Ensured that `max_refresh_attempts` must be greater than zero, preventing invalid configurations.
	- Enhanced clarity in the instantiation of StravaClient within the service provider by explicitly naming parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->